### PR TITLE
Fix shifting textbox when status icon changes.

### DIFF
--- a/MultiCopierWPF/Views/Windows/MainWindow.xaml
+++ b/MultiCopierWPF/Views/Windows/MainWindow.xaml
@@ -114,7 +114,6 @@
                     Content="+ Add Backup" />
             </Grid>
 
-
             <ScrollViewer MaxHeight="230" VerticalScrollBarVisibility="Auto">
                 <ItemsControl ItemsSource="{Binding BackupLocations}">
                     <ItemsControl.ItemTemplate>
@@ -127,7 +126,7 @@
                                 CornerRadius="4">
                                 <Grid>
                                     <Grid.ColumnDefinitions>
-                                        <ColumnDefinition Width="Auto" />
+                                        <ColumnDefinition Width="25" />
                                         <ColumnDefinition Width="*" />
                                         <ColumnDefinition Width="Auto" />
                                     </Grid.ColumnDefinitions>


### PR DESCRIPTION
Set a fixed width for the status column to prevent the textbox from shifting when the status icon goes from any to the "processing" gif and back.